### PR TITLE
Fix : Update translation for 'Social' in multiple languages and enhance SocialScreen layout

### DIFF
--- a/lib/core/translations/en.json
+++ b/lib/core/translations/en.json
@@ -66,7 +66,7 @@
   "NavigationBar": {
     "Home": "Home",
     "More": "More",
-    "Social": "Social",
+    "Social": "Rank",
     "Statistics": "Statistics",
     "Timer": "Timer"
   },

--- a/lib/core/translations/ja.json
+++ b/lib/core/translations/ja.json
@@ -66,7 +66,7 @@
   "NavigationBar": {
     "Home": "ホーム",
     "More": "もっと見る",
-    "Social": "ソーシャル",
+    "Social": "ランク",
     "Statistics": "統計",
     "Timer": "タイマー"
   },

--- a/lib/core/translations/ko.json
+++ b/lib/core/translations/ko.json
@@ -66,7 +66,7 @@
   "NavigationBar": {
     "Home": "홈",
     "More": "더보기",
-    "Social": "소셜",
+    "Social": "랭킹",
     "Statistics": "통계",
     "Timer": "타이머"
   },

--- a/lib/core/translations/th.json
+++ b/lib/core/translations/th.json
@@ -66,7 +66,7 @@
   "NavigationBar": {
     "Home": "หน้าแรก",
     "More": "เพิ่มเติม",
-    "Social": "สังคม",
+    "Social": "อันดับ",
     "Statistics": "สถิติ",
     "Timer": "จับเวลา"
   },

--- a/lib/core/translations/vi.json
+++ b/lib/core/translations/vi.json
@@ -66,9 +66,9 @@
   "NavigationBar": {
     "Home": "Trang chủ",
     "More": "Thêm",
-    "Social": "Xã hội",
+    "Social": "Hạng",
     "Statistics": "Thống kê",
-    "Timer": "Bộ đếm giờ"
+    "Timer": "Hẹn giờ"
   },
   "NotificationButton": {
     "Alarm": "Thông báo"

--- a/lib/core/translations/zh.json
+++ b/lib/core/translations/zh.json
@@ -66,7 +66,7 @@
   "NavigationBar": {
     "Home": "首页",
     "More": "更多",
-    "Social": "社交",
+    "Social": "排名",
     "Statistics": "统计",
     "Timer": "计时器"
   },

--- a/lib/src/views/social/views/social_screen.dart
+++ b/lib/src/views/social/views/social_screen.dart
@@ -2,28 +2,133 @@ import 'package:flutter/material.dart';
 
 import '../../../../core/router/bottom_nav_bar.dart';
 
-class SocialScreen extends StatelessWidget {
+class SocialScreen extends StatefulWidget {
   const SocialScreen({super.key});
+
+  @override
+  State<SocialScreen> createState() => _SocialScreenState();
+}
+
+class _SocialScreenState extends State<SocialScreen> {
+  bool showFriendsOnly = false;
+
+  final List<Map<String, dynamic>> leaderboard = [
+    {"name": "Rozkyczi", "score": 4396, "avatar": "👑"},
+    {"name": "joshtheboss6912", "score": 730, "avatar": "🎩"},
+    {"name": "ValiantCleric5709", "score": 221, "avatar": "🧙‍♂️"},
+    {"name": "AuspiciousCard89366", "score": 181, "avatar": "🐨"},
+    {"name": "HypnoticBlade78605", "score": 141, "avatar": "🧢"},
+    {"name": "Makart2", "score": 118, "avatar": "🧁"},
+  ];
+
+  String formatDuration(int seconds) {
+    Duration duration = Duration(seconds: seconds);
+    String twoDigits(int n) => n.toString().padLeft(2, '0');
+    String hours = twoDigits(duration.inHours);
+    String minutes = twoDigits(duration.inMinutes.remainder(60));
+    String secs = twoDigits(duration.inSeconds.remainder(60));
+    return "$hours:$minutes:$secs";
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(),
-      body: SafeArea(
-        child: Center(
-          child: ListView.builder(
-            itemCount: 10,
-            itemBuilder: (context, index) {
-              return ListTile(
-                leading: CircleAvatar(
-                  child: Text("${index + 1}"),
+      body: Column(
+        children: [
+          const SizedBox(height: 20),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 20),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text("All Time",
+                    style:
+                        TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+                Row(
+                  children: [
+                    const Text("All",
+                        style: TextStyle(fontWeight: FontWeight.bold)),
+                    Switch(
+                      value: showFriendsOnly,
+                      activeColor: Colors.deepPurple,
+                      onChanged: (value) =>
+                          setState(() => showFriendsOnly = value),
+                    ),
+                    const Text("Friends",
+                        style: TextStyle(fontWeight: FontWeight.bold)),
+                  ],
                 ),
-                title: Text("닉네임 ${index + 1}"),
-                subtitle: Text("공부 시간: ${12 - index}시간 ${index * 5}분"),
-              );
-            },
+              ],
+            ),
           ),
-        ),
+          Expanded(
+            child: ListView.builder(
+              itemCount: leaderboard.length,
+              itemBuilder: (context, index) {
+                final player = leaderboard[index];
+                return AnimatedContainer(
+                  duration: const Duration(milliseconds: 500),
+                  curve: Curves.easeInOut,
+                  margin:
+                      const EdgeInsets.symmetric(horizontal: 20, vertical: 8),
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(15),
+                    gradient: index == 0
+                        ? const LinearGradient(
+                            colors: [Colors.amber, Colors.orange])
+                        : index == 1
+                            ? LinearGradient(
+                                colors: [Colors.grey[200]!, Colors.grey[400]!])
+                            : index == 2
+                                ? LinearGradient(colors: [
+                                    Colors.brown[100]!,
+                                    Colors.brown[300]!
+                                  ])
+                                : const LinearGradient(
+                                    colors: [Colors.white, Colors.white]),
+                    boxShadow: const [
+                      BoxShadow(
+                        color: Colors.black12,
+                        blurRadius: 5,
+                        spreadRadius: 1,
+                      ),
+                    ],
+                  ),
+                  child: ListTile(
+                    leading: CircleAvatar(
+                      backgroundColor: Colors.deepPurple,
+                      child: Text(player["avatar"],
+                          style: const TextStyle(fontSize: 24)),
+                    ),
+                    title: Text(player["name"],
+                        style: const TextStyle(fontWeight: FontWeight.bold)),
+                    subtitle: Text("공부시간: ${formatDuration(player["score"])}",
+                        style: const TextStyle(color: Colors.black54)),
+                    trailing: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        if (index == 0)
+                          const Icon(Icons.emoji_events,
+                              color: Colors.yellow, size: 28),
+                        if (index == 1)
+                          const Icon(Icons.emoji_events,
+                              color: Colors.grey, size: 28),
+                        if (index == 2)
+                          const Icon(Icons.emoji_events,
+                              color: Colors.brown, size: 28),
+                        const SizedBox(width: 8),
+                        Text("Rank ${index + 1}",
+                            style: const TextStyle(
+                                fontWeight: FontWeight.bold, fontSize: 16)),
+                      ],
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+        ],
       ),
       bottomNavigationBar: BottomNavBar(),
     );

--- a/lib/src/views/social/views/social_screen.dart
+++ b/lib/src/views/social/views/social_screen.dart
@@ -1,4 +1,3 @@
-import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 
 import '../../../../core/router/bottom_nav_bar.dart';
@@ -12,7 +11,18 @@ class SocialScreen extends StatelessWidget {
       appBar: AppBar(),
       body: SafeArea(
         child: Center(
-          child: Text(tr("SocialScreen")),
+          child: ListView.builder(
+            itemCount: 10,
+            itemBuilder: (context, index) {
+              return ListTile(
+                leading: CircleAvatar(
+                  child: Text("${index + 1}"),
+                ),
+                title: Text("닉네임 ${index + 1}"),
+                subtitle: Text("공부 시간: ${12 - index}시간 ${index * 5}분"),
+              );
+            },
+          ),
         ),
       ),
       bottomNavigationBar: BottomNavBar(),


### PR DESCRIPTION
## 📌 PR 요약

바텀 네비게이션 바의 소셜을 임시로 랭킹으로 변경

## 🛠 변경 내용

- 가짜 데이터로 랭킹페이지의 랭킹 구현 (추후 진짜 데이터로 변경예정)

## 🔍 리뷰 요청 사항

<!-- PR에 대한 중점적인 리뷰 요청사항이 있다면 작성해주세요. -->

## 📋 참고 사항

<!-- PR에 대한 추가적인 설명이나 참고 사항이 있다면 작성해주세요. -->