### PR TITLE
프로필 이미지 사이즈 조종

### DIFF
--- a/lib/src/viewmodels/image_controller.dart
+++ b/lib/src/viewmodels/image_controller.dart
@@ -56,8 +56,8 @@ class ImageController {
         ],
         compressFormat: ImageCompressFormat.jpg,
         compressQuality: 50,
-        maxWidth: 200,
-        maxHeight: 200,
+        maxWidth: 100,
+        maxHeight: 100,
       );
       return croppedFile != null ? File(croppedFile.path) : null;
     } catch (e) {


### PR DESCRIPTION
## 📌 PR 요약

이미지 로딩 속도와 데이터를 아끼기위해 100PX로 변경
광고 사이즈 조종 및 패딩

