### PR TITLE
Fix/ux focus breathing_ver 1.1로 배포 수정 버전

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -397,15 +397,15 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   AppAuth: d4f13a8fe0baf391b2108511793e4b479691fb73
-  cloud_firestore: 56e7bb3888f09698dc061d38d02d87d4fd80e2cb
-  connectivity_plus: 2a701ffec2c0ae28a48cf7540e279787e77c447d
-  device_info_plus: bf2e3232933866d73fe290f2942f2156cdd10342
+  cloud_firestore: e61acbf808607d2c88ee32b00cd3aec027b38b3c
+  connectivity_plus: cb623214f4e1f6ef8fe7403d580fdad517d2f7dd
+  device_info_plus: 21fcca2080fbcd348be798aa36c3e5ed849eefbe
   Firebase: d80354ed7f6df5f9aca55e9eb47cc4b634735eaf
-  firebase_analytics: 7ec1166af61987fa968766eb11587c562a5650ee
-  firebase_auth: b19346631c01e14b00cf1c37a87c003ecfdc8396
-  firebase_core: ac395f994af4e28f6a38b59e05a88ca57abeb874
-  firebase_messaging: 11cb3411d2e465103a7f8e5119bab5b92bb820a3
-  firebase_storage: 91cc60afa5ee83fd1647e661dcfd53e5fcb74d51
+  firebase_analytics: d9a47ad8168f1da7bab57cd1400833d2bc48a043
+  firebase_auth: 342560b5af9939733fa3f9d5be7ee7e4456c9e71
+  firebase_core: 8d552814f6c01ccde5d88939fced4ec26f2f5510
+  firebase_messaging: f1d05960bc9b9139184e3b1cd4e3cf73caf7be36
+  firebase_storage: 928248385247e850af249a77cc71b7a201d82380
   FirebaseAnalytics: 4fd42def128146e24e480e89f310e3d8534ea42b
   FirebaseAppCheckInterop: 7bf86d55a2b7e9bd91464120eba3e52e4b63b2e2
   FirebaseAuth: ad59a1a7b161e75f74c39f70179d2482d40e2737
@@ -425,14 +425,14 @@ SPEC CHECKSUMS:
   FirebaseSharedSwift: 672954eac7b141d6954fab9a32d45d6b1d922df8
   FirebaseStorage: 8eede00081a6ce904eaa8d2daa66f1e053e8e6ea
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_email_sender: 10a22605f92809a11ef52b2f412db806c6082d40
-  flutter_local_notifications: df98d66e515e1ca797af436137b4459b160ad8c9
-  flutter_secure_storage: d33dac7ae2ea08509be337e775f6b59f1ff45f12
-  flutter_sound: 094823bc99ca323422808f386c6f597ea157dc49
+  flutter_email_sender: 2397f5e84aaacfb61af569637a963e7c687858d8
+  flutter_local_notifications: 395056b3175ba4f08480a7c5de30cd36d69827e4
+  flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13
+  flutter_sound: 9e4f2c89d07c223eb42bf78ea1cd6226034a4911
   flutter_sound_core: 8d3c08efc430a06debc49a627f9b651b542e8351
   Google-Mobile-Ads-SDK: 14f57f2dc33532a24db288897e26494640810407
-  google_mobile_ads: fe0e2c1764ad95323dd0e3081d0bb2d58411f957
-  google_sign_in_ios: 07375bfbf2620bc93a602c0e27160d6afc6ead38
+  google_mobile_ads: 16ad301354fa6a7ea55770c6254bd4339bf8558b
+  google_sign_in_ios: 0ab078e60da6dfe23cbc55c83502b52bba1aad63
   GoogleAppMeasurement: fc0817122bd4d4189164f85374e06773b9561896
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleSignIn: d4281ab6cf21542b1cfaff85c191f230b399d2db
@@ -440,25 +440,25 @@ SPEC CHECKSUMS:
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
   GTMAppAuth: f69bd07d68cd3b766125f7e072c45d7340dea0de
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
-  haptic_feedback: 8cb3ee0cb6b797946c2b0df9c99ebc8f7ed79c71
-  image_cropper: 37d40f62177c101ff4c164906d259ea2c3aa70cf
-  image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
-  in_app_review: a31b5257259646ea78e0e35fc914979b0031d011
+  haptic_feedback: fd1d8509833f58f164fc12122c0357fa9b2750e0
+  image_cropper: 5f162dcf988100dc1513f9c6b7eb42cd6fbf9156
+  image_picker_ios: 7fe1ff8e34c1790d6fff70a32484959f563a928a
+  in_app_review: 5596fe56fab799e8edb3561c03d053363ab13457
   leveldb-library: cc8b8f8e013647a295ad3f8cd2ddf49a6f19be19
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
-  package_info_plus: c0502532a26c7662a62a356cebe2692ec5fe4ec4
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
+  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RecaptchaInterop: 7d1a4a01a6b2cb1610a47ef3f85f0c411434cb21
-  sensors_plus: 7229095999f30740798f0eeef5cd120357a8f4f2
-  share_plus: 8b6f8b3447e494cca5317c8c3073de39b3600d1f
-  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
-  sign_in_with_apple: f3bf75217ea4c2c8b91823f225d70230119b8440
+  sensors_plus: 6a11ed0c2e1d0bd0b20b4029d3bad27d96e0c65b
+  share_plus: 50da8cb520a8f0f65671c6c6a99b3617ed10a58a
+  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
+  sign_in_with_apple: c5dcc141574c8c54d5ac99dd2163c0c72ad22418
   TOCropViewController: 80b8985ad794298fb69d3341de183f33d1853654
-  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
-  wakelock_plus: 373cfe59b235a6dd5837d0fb88791d2f13a90d56
-  webview_flutter_wkwebview: a4af96a051138e28e29f60101d094683b9f82188
+  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
+  wakelock_plus: 04623e3f525556020ebd4034310f20fe7fda8b49
+  webview_flutter_wkwebview: 1821ceac936eba6f7984d89a9f3bcb4dea99ebb2
 
 PODFILE CHECKSUM: 6c570105ae5a585d4c15e78f6a958be054e062a0
 

--- a/lib/core/translations/ar.json
+++ b/lib/core/translations/ar.json
@@ -47,7 +47,7 @@
     "Cancel": "Cancel",
     "Confirm": "Confirm",
     "Focus!": "Focus!",
-    "YouarestudyingPutyourphonedownandfocus": "You are studying. Put your phone down and focus.",
+    "YouarestudyingPutyourphonedownandfocus": "You are studying.\nPut your phone down and focus.",
     "restoreTimer": "There is an existing timer. Do you want to restore it?",
     "LogoutDialog": "Are you sure you want to log out?",
     "DeleteUserDialog": "Are you sure you want to delete your account?"

--- a/lib/core/translations/da.json
+++ b/lib/core/translations/da.json
@@ -47,7 +47,7 @@
     "Cancel": "Annuller",
     "Confirm": "Bekræft",
     "Focus!": "Fokus!",
-    "YouarestudyingPutyourphonedownandfocus": "Du studerer. Læg din telefon væk og fokuser.",
+    "YouarestudyingPutyourphonedownandfocus": "Du studerer.\nLæg din telefon væk og fokuser.",
     "restoreTimer": "Der er en eksisterende timer. Vil du gendanne den?",
     "LogoutDialog": "Er du sikker på, at du vil logge ud?",
     "DeleteUserDialog": "Er du sikker på, at du vil slette din konto?"

--- a/lib/core/translations/de.json
+++ b/lib/core/translations/de.json
@@ -47,7 +47,7 @@
     "Cancel": "Cancel",
     "Confirm": "Confirm",
     "Focus!": "Focus!",
-    "YouarestudyingPutyourphonedownandfocus": "You are studying. Put your phone down and focus.",
+    "YouarestudyingPutyourphonedownandfocus": "You are studying.\nPut your phone down and focus.",
     "restoreTimer": "There is an existing timer. Do you want to restore it?",
     "LogoutDialog": "Are you sure you want to log out?",
     "DeleteUserDialog": "Are you sure you want to delete your account?"

--- a/lib/core/translations/en.json
+++ b/lib/core/translations/en.json
@@ -47,7 +47,7 @@
     "Cancel": "Cancel",
     "Confirm": "Confirm",
     "Focus!": "Focus!",
-    "YouarestudyingPutyourphonedownandfocus": "You are studying. Put your phone down and focus.",
+    "YouarestudyingPutyourphonedownandfocus": "You are studying.\nPut your phone down and focus.",
     "restoreTimer": "There is an existing timer. Do you want to restore it?",
     "LogoutDialog": "Are you sure you want to log out?",
     "DeleteUserDialog": "Are you sure you want to delete your account?"

--- a/lib/core/translations/es.json
+++ b/lib/core/translations/es.json
@@ -47,7 +47,7 @@
     "Cancel": "Cancel",
     "Confirm": "Confirm",
     "Focus!": "Focus!",
-    "YouarestudyingPutyourphonedownandfocus": "You are studying. Put your phone down and focus.",
+    "YouarestudyingPutyourphonedownandfocus": "You are studying.\nPut your phone down and focus.",
     "restoreTimer": "There is an existing timer. Do you want to restore it?",
     "LogoutDialog": "Are you sure you want to log out?",
     "DeleteUserDialog": "Are you sure you want to delete your account?"

--- a/lib/core/translations/fr.json
+++ b/lib/core/translations/fr.json
@@ -47,7 +47,7 @@
     "Cancel": "Cancel",
     "Confirm": "Confirm",
     "Focus!": "Focus!",
-    "YouarestudyingPutyourphonedownandfocus": "You are studying. Put your phone down and focus.",
+    "YouarestudyingPutyourphonedownandfocus": "You are studying.\nPut your phone down and focus.",
     "restoreTimer": "There is an existing timer. Do you want to restore it?",
     "LogoutDialog": "Are you sure you want to log out?",
     "DeleteUserDialog": "Are you sure you want to delete your account?"

--- a/lib/core/translations/hi.json
+++ b/lib/core/translations/hi.json
@@ -47,7 +47,7 @@
     "Cancel": "रद्द करें",
     "Confirm": "पुष्टि करें",
     "Focus!": "ध्यान दें!",
-    "YouarestudyingPutyourphonedownandfocus": "आप पढ़ रहे हैं। अपना फ़ोन नीचे रखें और ध्यान केंद्रित करें।",
+    "YouarestudyingPutyourphonedownandfocus": "आप पढ़ रहे हैं। \nअपना फ़ोन नीचे रखें और ध्यान केंद्रित करें।",
     "restoreTimer": "एक मौजूदा टाइमर है। क्या आप इसे पुनर्स्थापित करना चाहते हैं?",
     "LogoutDialog": "क्या आप वाकई लॉग आउट करना चाहते हैं?",
     "DeleteUserDialog": "क्या आप वाकई अपना खाता हटाना चाहते हैं?"

--- a/lib/core/translations/it.json
+++ b/lib/core/translations/it.json
@@ -47,7 +47,7 @@
     "Cancel": "Cancel",
     "Confirm": "Confirm",
     "Focus!": "Focus!",
-    "YouarestudyingPutyourphonedownandfocus": "You are studying. Put your phone down and focus.",
+    "YouarestudyingPutyourphonedownandfocus": "You are studying.\nPut your phone down and focus.",
     "restoreTimer": "There is an existing timer. Do you want to restore it?",
     "LogoutDialog": "Are you sure you want to log out?",
     "DeleteUserDialog": "Are you sure you want to delete your account?"

--- a/lib/core/translations/ja.json
+++ b/lib/core/translations/ja.json
@@ -47,7 +47,7 @@
     "Cancel": "キャンセル",
     "Confirm": "確認",
     "Focus!": "集中してください！",
-    "YouarestudyingPutyourphonedownandfocus": "勉強中です。携帯電話を置いて集中してください。",
+    "YouarestudyingPutyourphonedownandfocus": "勉強中です\n携帯電話を置いて集中してください。",
     "restoreTimer": "既存のタイマーがあります。復元しますか？",
     "LogoutDialog": "ログアウトしますか？",
     "DeleteUserDialog": "本当にアカウントを削除しますか？"

--- a/lib/core/translations/ko.json
+++ b/lib/core/translations/ko.json
@@ -47,7 +47,7 @@
     "Cancel": "취소",
     "Confirm": "확인",
     "Focus!": "집중하세요!",
-    "YouarestudyingPutyourphonedownandfocus": "공부 중입니다. 핸드폰을 내려놓고 집중하세요.",
+    "YouarestudyingPutyourphonedownandfocus": "공부 중입니다.\n핸드폰을 내려놓고 집중하세요.",
     "restoreTimer": "기존의 타이머가 있습니다. 복구하시겠습니까?",
     "LogoutDialog": "로그아웃하시겠습니까?",
     "DeleteUserDialog": "정말로 탈퇴하시겠습니까?"

--- a/lib/core/translations/ru.json
+++ b/lib/core/translations/ru.json
@@ -47,7 +47,7 @@
     "Cancel": "Cancel",
     "Confirm": "Confirm",
     "Focus!": "Focus!",
-    "YouarestudyingPutyourphonedownandfocus": "You are studying. Put your phone down and focus.",
+    "YouarestudyingPutyourphonedownandfocus": "You are studying.\nPut your phone down and focus.",
     "restoreTimer": "There is an existing timer. Do you want to restore it?",
     "LogoutDialog": "Are you sure you want to log out?",
     "DeleteUserDialog": "Are you sure you want to delete your account?"

--- a/lib/core/translations/th.json
+++ b/lib/core/translations/th.json
@@ -47,7 +47,7 @@
     "Cancel": "ยกเลิก",
     "Confirm": "ยืนยัน",
     "Focus!": "จดจ่อ!",
-    "YouarestudyingPutyourphonedownandfocus": "คุณกำลังเรียนอยู่ วางโทรศัพท์แล้วมุ่งมั่นไปที่การเรียน",
+    "YouarestudyingPutyourphonedownandfocus": "คุณกำลังเรียนอยู่\nวางโทรศัพท์แล้วมุ่งมั่นไปที่การเรียน",
     "restoreTimer": "มีตัวจับเวลาที่มีอยู่แล้ว คุณต้องการกู้คืนหรือไม่?",
     "LogoutDialog": "คุณแน่ใจหรือไม่ว่าต้องการออกจากระบบ?",
     "DeleteUserDialog": "คุณแน่ใจหรือไม่ว่าต้องการลบบัญชี?"

--- a/lib/core/translations/vi.json
+++ b/lib/core/translations/vi.json
@@ -47,7 +47,7 @@
     "Cancel": "Hủy bỏ",
     "Confirm": "Xác nhận",
     "Focus!": "Hãy tập trung!",
-    "YouarestudyingPutyourphonedownandfocus": "Bạn đang học. Hãy bỏ điện thoại xuống và tập trung.",
+    "YouarestudyingPutyourphonedownandfocus": "Bạn đang học.\nHãy bỏ điện thoại xuống và tập trung.",
     "restoreTimer": "Có một bộ đếm thời gian hiện tại. Bạn có muốn khôi phục không?",
     "LogoutDialog": "Bạn có chắc chắn muốn đăng xuất không?",
     "DeleteUserDialog": "Bạn có chắc chắn muốn xóa tài khoản không?"

--- a/lib/core/translations/zh.json
+++ b/lib/core/translations/zh.json
@@ -47,7 +47,7 @@
     "Cancel": "取消",
     "Confirm": "确认",
     "Focus!": "专心！",
-    "YouarestudyingPutyourphonedownandfocus": "你正在学习。放下手机，专心致志。",
+    "YouarestudyingPutyourphonedownandfocus": "你正在学习。\n放下手机，专心致志。",
     "restoreTimer": "已有计时器。你想恢复吗？",
     "LogoutDialog": "你确定要退出登录吗？",
     "DeleteUserDialog": "你确定要删除账户吗？"

--- a/lib/src/views/home/home_screen.dart
+++ b/lib/src/views/home/home_screen.dart
@@ -48,59 +48,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   void initState() {
     super.initState();
     // 위젯이 처음 생성될 때 _showBottomSheet 함수를 호출합니다. (타이머가 실행 중이지 않을 때만)
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      // Read the timer state using ref
-      final isTimerRunning = ref.read(suDuckTimerProvider).isRunning;
-      if (!isTimerRunning) {
-        _showBottomSheet();
-      }
-    });
-  }
-
-  void _showBottomSheet() {
-    showModalBottomSheet(
-      context: context,
-      isScrollControlled:
-          true, // Keep true if content might exceed screen height initially
-      builder: (BuildContext context) {
-        // Give the container a fixed height to prevent resizing
-        return Container(
-          height: 400.h, // Set a fixed height
-          width: double.infinity,
-          // color: Colors.transparent, // Color is often set by theme, can remove if default is fine
-          padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 16.h),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              // Replace the Text widget with the BreathingExerciseWidget
-              SizedBox(
-                  height: 160.h, // Add some space above the exercise
-                  child: const BreathingExerciseWidget()),
-              SizedBox(height: 16.h), // Add some space below the exercise
-              AdMobWidget.showBannerAd(80.h), // 실제 광고 위젯
-              SizedBox(height: 16.h),
-              SizedBox(
-                width: double.infinity,
-                child: ElevatedButton(
-                    onPressed: () {
-                      Navigator.pop(context);
-                    },
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: Colors.blue,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                      padding: EdgeInsets.symmetric(vertical: 12.h),
-                    ),
-                    child: Text(tr("Common.Close"),
-                        style:
-                            TextStyle(fontSize: 16.sp, color: Colors.white))),
-              ),
-            ],
-          ),
-        );
-      },
-    );
+    WidgetsBinding.instance.addPostFrameCallback((_) {});
   }
 
   @override

--- a/lib/src/views/home/home_seg1_screen.dart
+++ b/lib/src/views/home/home_seg1_screen.dart
@@ -17,7 +17,7 @@ class Seg1Screen extends StatelessWidget {
           SuDuckTimerWidget(),
           SuduckTimerControllBarWidget(),
           SubjectListWidget(),
-          AdMobWidget.showBannerAd(60),
+          AdMobWidget.showBannerAd(60, true),
         ],
       ),
     );

--- a/lib/src/views/home/home_seg2_screen.dart
+++ b/lib/src/views/home/home_seg2_screen.dart
@@ -13,7 +13,7 @@ class Seg2Screen extends StatelessWidget {
       children: [
         DDayListTileWidget(),
         Spacer(),
-        AdMobWidget.showBannerAd(50, true),
+        AdMobWidget.showBannerAd(50),
       ],
     );
   }

--- a/lib/src/views/home/suduck_timer_focus_mode_screen.dart
+++ b/lib/src/views/home/suduck_timer_focus_mode_screen.dart
@@ -31,22 +31,69 @@ class _SuduckTimerFocusModeWidgetState
 
   StreamSubscription? _accelerometerSubscription;
   bool _isAlertVisible = false;
-  Timer? _alertTimer;
-  DateTime? _lastMovementTime;
   Color? _lastColor;
   Color? _currentBgColor;
+  String? _temporaryMessage;
+  Timer? _resetTimer;
+  bool _canProcessMovement = true;
 
   // 설정값
   DateTime? _lastDialogTime; // 마지막 대화창 시간
   double _previousX = 0, _previousY = 0, _previousZ = 0; // 가속도 값 초기화
-  final double _movementThreshold = 2.2; // 움직임 감지 임계값
+  final double _movementThreshold = 1.2; // 움직임 감지 임계값을 낮춰 더 민감하게
   final Duration _dialogCooldown = Duration(seconds: 60); // 다이얼로그후 설정값이 지나야 재감지
 
-  final int _inactiveThreshold = 10; // 설정시간동안 움직이지 않으면 다이얼로그 닫음
+  final int _inactiveThreshold = 3; // 설정시간동안 움직이지 않으면 다이얼로그 닫음
 
   // 추가할 변수들
   bool _isInitialized = false;
-  final _initializationDelay = const Duration(seconds: 60); //감지 초기화 지연시간
+  final _initializationDelay = const Duration(seconds: 10); //감지 초기화 지연시간
+  int _consecutiveMovements = 0; // 연속된 움직임 감지 횟수
+  final int _requiredConsecutiveMovements = 2; // 필요한 연속 움직임 횟수
+  DateTime? _lastMovementDetectionTime;
+  final Duration _movementResetDuration =
+      Duration(milliseconds: 500); // 움직임 초기화 시간
+  bool _isProcessingMovement = false;
+
+  void _resetAllStates() {
+    if (mounted) {
+      setState(() {
+        _isAlertVisible = false;
+        _temporaryMessage = null;
+        _isProcessingMovement = false;
+        _consecutiveMovements = 0;
+        _previousX = 0;
+        _previousY = 0;
+        _previousZ = 0;
+        _canProcessMovement = true;
+      });
+    }
+  }
+
+  void _showConcentrationAlert() async {
+    if (!mounted || _isAlertVisible) return;
+
+    try {
+      _resetTimer?.cancel();
+      _resetTimer = null;
+
+      setState(() {
+        _isAlertVisible = true;
+        _temporaryMessage = tr("Dialog.YouarestudyingPutyourphonedownandfocus");
+        _canProcessMovement = false;
+      });
+
+      await SelectionHaptic.warning();
+
+      _resetTimer = Timer(Duration(seconds: _inactiveThreshold), () {
+        _resetAllStates();
+        debugPrint('Timer reset completed');
+      });
+    } catch (e) {
+      debugPrint('Error in showConcentrationAlert: $e');
+      _resetAllStates();
+    }
+  }
 
   @override
   void initState() {
@@ -82,19 +129,15 @@ class _SuduckTimerFocusModeWidgetState
     super.didChangeDependencies();
     _lastColor = ref.read(timerBgColorProvider);
     _currentBgColor = ref.read(timerBgColorProvider);
+    if (_isAlertVisible) {
+      _resetTimer = Timer(Duration(seconds: _inactiveThreshold), () {
+        _resetAllStates();
+      });
+    }
   }
 
   void _checkNoMovement() {
-    if (_lastMovementTime != null &&
-        DateTime.now().difference(_lastMovementTime!) >
-            Duration(seconds: _inactiveThreshold)) {
-      if (mounted && _isAlertVisible) {
-        Navigator.of(context).pop();
-        setState(() {
-          _isAlertVisible = false;
-        });
-      }
-    }
+    // This method is now empty as the logic has been updated
   }
 
   void updateAnimation(Color newColor) {
@@ -113,9 +156,11 @@ class _SuduckTimerFocusModeWidgetState
 
   @override
   void dispose() {
+    _resetTimer?.cancel();
+    _resetTimer = null;
     _isInitialized = false;
     _stopAccelerometer();
-    _alertTimer?.cancel();
+    _canProcessMovement = false;
 
     if (_colorController.isAnimating) {
       _colorController.stop();
@@ -133,94 +178,79 @@ class _SuduckTimerFocusModeWidgetState
   }
 
   void _startAccelerometer() {
+    _stopAccelerometer();
     _accelerometerSubscription ??=
-        accelerometerEventStream().listen((AccelerometerEvent event) {
-      if (!mounted || !_isInitialized || _isAlertVisible) return;
+        accelerometerEventStream(samplingPeriod: Duration(milliseconds: 1500))
+            .listen((AccelerometerEvent event) {
+      if (!mounted ||
+          !_isInitialized ||
+          _isAlertVisible ||
+          !_canProcessMovement) return;
 
       // 움직임 계산
-      double deltaX = (_previousX - event.x).abs();
-      double deltaY = (_previousY - event.y).abs();
-      double deltaZ = (_previousZ - event.z).abs();
+      try {
+        double deltaX = (_previousX - event.x).abs();
+        double deltaY = (_previousY - event.y).abs();
+        double deltaZ = (_previousZ - event.z).abs();
 
-      // 첫 번째 값 설정
-      if (_previousX == 0 && _previousY == 0 && _previousZ == 0) {
+        // 첫 번째 값 설정
+        if (_previousX == 0 && _previousY == 0 && _previousZ == 0) {
+          _previousX = event.x;
+          _previousY = event.y;
+          _previousZ = event.z;
+          return;
+        }
+
+        DateTime now = DateTime.now();
+        bool isMovementExpired = _lastMovementDetectionTime == null ||
+            now.difference(_lastMovementDetectionTime!) >
+                _movementResetDuration;
+
+        if (isMovementExpired) {
+          _consecutiveMovements = 0;
+        }
+
         _previousX = event.x;
         _previousY = event.y;
         _previousZ = event.z;
-        return;
-      }
 
-      _previousX = event.x;
-      _previousY = event.y;
-      _previousZ = event.z;
+        bool isMoving = (deltaX > _movementThreshold ||
+            deltaY > _movementThreshold ||
+            deltaZ > _movementThreshold);
 
-      bool isMoving = (deltaX > _movementThreshold ||
-          deltaY > _movementThreshold ||
-          deltaZ > _movementThreshold);
+        if (isMoving) {
+          _consecutiveMovements++;
+          _lastMovementDetectionTime = now;
+        }
 
-      DateTime now = DateTime.now();
-      bool isCooldownOver = _lastDialogTime == null ||
-          now.difference(_lastDialogTime!) > _dialogCooldown;
+        bool isCooldownOver = _lastDialogTime == null ||
+            now.difference(_lastDialogTime!) > _dialogCooldown;
 
-      if (isMoving && isCooldownOver) {
-        _lastDialogTime = now;
-        if (!_isAlertVisible) {
+        if (_consecutiveMovements >= _requiredConsecutiveMovements &&
+            isCooldownOver &&
+            _canProcessMovement) {
+          _consecutiveMovements = 0;
+          _lastDialogTime = now;
           _showConcentrationAlert();
         }
+      } catch (e) {
+        debugPrint('Error processing accelerometer event: $e');
+        _resetAllStates();
       }
     });
   }
 
   void _stopAccelerometer() {
-    _accelerometerSubscription?.cancel();
-    _accelerometerSubscription = null;
+    if (_accelerometerSubscription != null) {
+      _accelerometerSubscription?.cancel();
+      _accelerometerSubscription = null;
+    }
   }
 
-  void _showConcentrationAlert() async {
-    if (!mounted || _isAlertVisible) return;
-
-    setState(() {
-      _isAlertVisible = true;
-    });
-    await SelectionHaptic.warning();
-    showDialog(
-      context: context,
-      barrierDismissible: false,
-      builder: (BuildContext context) {
-        _alertTimer?.cancel();
-        _alertTimer = Timer(Duration(seconds: _inactiveThreshold), () {
-          if (mounted && _isAlertVisible) {
-            Navigator.of(context).pop();
-            setState(() {
-              _isAlertVisible = false;
-            });
-          }
-        });
-
-        return AlertDialog(
-          title: Center(child: Text("Dialog.Focus!").tr()),
-          content: Container(
-            width: 280.w,
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text("Dialog.YouarestudyingPutyourphonedownandfocus").tr(),
-                Gap(20),
-              ],
-            ),
-          ),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(12),
-          ),
-        );
-      },
-    ).then((_) {
-      if (mounted) {
-        setState(() {
-          _isAlertVisible = false;
-        });
-      }
-    });
+  @override
+  void didUpdateWidget(SuduckTimerFocusModeWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // This method is now empty as the logic has been updated
   }
 
   @override
@@ -233,6 +263,12 @@ class _SuduckTimerFocusModeWidgetState
     updateAnimation(bgColor);
 
     final bool isRunning = suduckTimer.isRunning;
+
+    if (_isAlertVisible && _resetTimer == null) {
+      _resetTimer = Timer(Duration(seconds: _inactiveThreshold), () {
+        _resetAllStates();
+      });
+    }
 
     return Scaffold(
       body: Center(
@@ -289,6 +325,7 @@ class _SuduckTimerFocusModeWidgetState
                       suduckTimer: suduckTimer,
                       isRunning: isRunning,
                       suduckTimerNotifier: suduckTimerNotifier,
+                      temporaryMessage: _temporaryMessage,
                     ),
                   ),
                 ),
@@ -321,12 +358,14 @@ class TimerCenter extends StatelessWidget {
     required this.suduckTimer,
     required this.isRunning,
     required this.suduckTimerNotifier,
+    required this.temporaryMessage,
   }) : _colorAnimation = colorAnimation;
 
   final Animation<Color?> _colorAnimation;
   final TimerState suduckTimer;
   final bool isRunning;
   final SuDuckTimer suduckTimerNotifier;
+  final String? temporaryMessage;
 
   @override
   Widget build(BuildContext context) {
@@ -363,15 +402,29 @@ class TimerCenter extends StatelessWidget {
             width: double.infinity,
             color: _colorAnimation.value,
             child: Center(
-              child: Text(
-                getFormatTime(suduckTimer.elapsedTime),
-                style: TextStyle(
-                  fontSize: 46.sp,
-                  fontWeight: FontWeight.w600,
-                  color: Colors.white,
-                  fontFeatures: [FontFeature.tabularFigures()],
-                ),
-              ),
+              child: temporaryMessage != null
+                  ? Container(
+                      padding: EdgeInsets.symmetric(horizontal: 20.w),
+                      child: Text(
+                        temporaryMessage!,
+                        textAlign: TextAlign.center,
+                        style: TextStyle(
+                          fontSize: 14.sp,
+                          height: 1.4,
+                          fontWeight: FontWeight.w500,
+                          color: Colors.white,
+                        ),
+                      ),
+                    )
+                  : Text(
+                      getFormatTime(suduckTimer.elapsedTime),
+                      style: TextStyle(
+                        fontSize: 46.sp,
+                        fontWeight: FontWeight.w600,
+                        color: Colors.white,
+                        fontFeatures: [FontFeature.tabularFigures()],
+                      ),
+                    ),
             ),
           ),
         ),

--- a/lib/src/views/home/suduck_timer_focus_mode_screen.dart
+++ b/lib/src/views/home/suduck_timer_focus_mode_screen.dart
@@ -5,13 +5,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
-import 'package:gap/gap.dart';
 import 'package:sensors_plus/sensors_plus.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
 
 import '../../../core/utils/get_formatted_time.dart';
 import '../../../core/utils/selection_haptic.dart';
-import '../../../core/widgets/admob_widget.dart';
 import '../../providers/suduck_timer/suduck_timer_provider_2_0.dart';
 import '../../viewmodels/timer/timer_bg_color_provider.dart';
 
@@ -35,28 +33,30 @@ class _SuduckTimerFocusModeWidgetState
   Color? _currentBgColor;
   String? _temporaryMessage;
   Timer? _resetTimer;
+  Timer? _hapticTimer;
   bool _canProcessMovement = true;
 
   // 설정값
   DateTime? _lastDialogTime; // 마지막 대화창 시간
   double _previousX = 0, _previousY = 0, _previousZ = 0; // 가속도 값 초기화
-  final double _movementThreshold = 1.2; // 움직임 감지 임계값을 낮춰 더 민감하게
-  final Duration _dialogCooldown = Duration(seconds: 60); // 다이얼로그후 설정값이 지나야 재감지
+  final double _movementThreshold = 1.5; // 핸드폰을 들어올리는 동작 감지를 위한 임계값
+  final Duration _dialogCooldown = Duration(seconds: 20); // 다이얼로그후 설정값이 지나야 재감지
 
   final int _inactiveThreshold = 3; // 설정시간동안 움직이지 않으면 다이얼로그 닫음
 
   // 추가할 변수들
   bool _isInitialized = false;
-  final _initializationDelay = const Duration(seconds: 10); //감지 초기화 지연시간
+  final _initializationDelay = const Duration(seconds: 15); //감지 초기화 지연시간
   int _consecutiveMovements = 0; // 연속된 움직임 감지 횟수
-  final int _requiredConsecutiveMovements = 2; // 필요한 연속 움직임 횟수
+  final int _requiredConsecutiveMovements = 3; // 필요한 연속 움직임 횟수
   DateTime? _lastMovementDetectionTime;
   final Duration _movementResetDuration =
-      Duration(milliseconds: 500); // 움직임 초기화 시간
+      Duration(milliseconds: 800); // 움직임 초기화 시간
   bool _isProcessingMovement = false;
 
   void _resetAllStates() {
     if (mounted) {
+      _stopHapticFeedback();
       setState(() {
         _isAlertVisible = false;
         _temporaryMessage = null;
@@ -71,11 +71,13 @@ class _SuduckTimerFocusModeWidgetState
   }
 
   void _showConcentrationAlert() async {
-    if (!mounted || _isAlertVisible) return;
+    if (!mounted) return;
 
     try {
+      if (!mounted || _isAlertVisible) return;
+
       _resetTimer?.cancel();
-      _resetTimer = null;
+      _hapticTimer?.cancel();
 
       setState(() {
         _isAlertVisible = true;
@@ -83,16 +85,37 @@ class _SuduckTimerFocusModeWidgetState
         _canProcessMovement = false;
       });
 
-      await SelectionHaptic.warning();
+      // 햅틱 피드백 시작
+      _startHapticFeedback();
 
       _resetTimer = Timer(Duration(seconds: _inactiveThreshold), () {
+        _stopHapticFeedback();
         _resetAllStates();
-        debugPrint('Timer reset completed');
       });
     } catch (e) {
       debugPrint('Error in showConcentrationAlert: $e');
+      _stopHapticFeedback();
       _resetAllStates();
     }
+  }
+
+  void _startHapticFeedback() {
+    // 초기 햅틱
+    HapticFeedback.mediumImpact();
+
+    // 500ms 간격으로 햅틱 피드백 반복
+    _hapticTimer = Timer.periodic(Duration(milliseconds: 500), (timer) {
+      if (mounted && _isAlertVisible) {
+        HapticFeedback.mediumImpact();
+      } else {
+        _stopHapticFeedback();
+      }
+    });
+  }
+
+  void _stopHapticFeedback() {
+    _hapticTimer?.cancel();
+    _hapticTimer = null;
   }
 
   @override
@@ -158,6 +181,7 @@ class _SuduckTimerFocusModeWidgetState
   void dispose() {
     _resetTimer?.cancel();
     _resetTimer = null;
+    _stopHapticFeedback();
     _isInitialized = false;
     _stopAccelerometer();
     _canProcessMovement = false;
@@ -180,7 +204,7 @@ class _SuduckTimerFocusModeWidgetState
   void _startAccelerometer() {
     _stopAccelerometer();
     _accelerometerSubscription ??=
-        accelerometerEventStream(samplingPeriod: Duration(milliseconds: 1500))
+        accelerometerEventStream(samplingPeriod: Duration(milliseconds: 2500))
             .listen((AccelerometerEvent event) {
       if (!mounted ||
           !_isInitialized ||
@@ -214,9 +238,13 @@ class _SuduckTimerFocusModeWidgetState
         _previousY = event.y;
         _previousZ = event.z;
 
-        bool isMoving = (deltaX > _movementThreshold ||
+        // 수직 방향(Z축) 변화에 더 큰 가중치 부여
+        bool isSignificantVerticalMovement = deltaZ > _movementThreshold * 1.2;
+        bool isGeneralMovement = (deltaX > _movementThreshold ||
             deltaY > _movementThreshold ||
             deltaZ > _movementThreshold);
+
+        bool isMoving = isSignificantVerticalMovement || isGeneralMovement;
 
         if (isMoving) {
           _consecutiveMovements++;
@@ -263,6 +291,14 @@ class _SuduckTimerFocusModeWidgetState
     updateAnimation(bgColor);
 
     final bool isRunning = suduckTimer.isRunning;
+    Color textColor = Colors.white;
+    if (_colorAnimation.value != null) {
+      if (_temporaryMessage != null) {
+        textColor = _getReadableTextColor(_colorAnimation.value!);
+      } else {
+        textColor = Colors.white;
+      }
+    }
 
     if (_isAlertVisible && _resetTimer == null) {
       _resetTimer = Timer(Duration(seconds: _inactiveThreshold), () {
@@ -349,6 +385,18 @@ class _SuduckTimerFocusModeWidgetState
       debugPrint('Wakelock enable error: $e');
     }
   }
+
+  Color _getReadableTextColor(Color backgroundColor) {
+    HSLColor hsl = HSLColor.fromColor(backgroundColor);
+
+    if (hsl.lightness > 0.7) {
+      return hsl.withLightness(0.2).toColor();
+    } else if (hsl.lightness < 0.3) {
+      return hsl.withLightness(0.9).toColor();
+    } else {
+      return hsl.withLightness(hsl.lightness < 0.5 ? 0.9 : 0.1).toColor();
+    }
+  }
 }
 
 class TimerCenter extends StatelessWidget {
@@ -369,6 +417,15 @@ class TimerCenter extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    Color textColor = Colors.white;
+    if (_colorAnimation.value != null) {
+      if (temporaryMessage != null) {
+        textColor = _getReadableTextColor(_colorAnimation.value!);
+      } else {
+        textColor = Colors.white;
+      }
+    }
+
     return Column(
       children: [
         Spacer(
@@ -412,7 +469,7 @@ class TimerCenter extends StatelessWidget {
                           fontSize: 14.sp,
                           height: 1.4,
                           fontWeight: FontWeight.w500,
-                          color: Colors.white,
+                          color: _getReadableTextColor(_colorAnimation.value!),
                         ),
                       ),
                     )
@@ -421,7 +478,7 @@ class TimerCenter extends StatelessWidget {
                       style: TextStyle(
                         fontSize: 46.sp,
                         fontWeight: FontWeight.w600,
-                        color: Colors.white,
+                        color: textColor,
                         fontFeatures: [FontFeature.tabularFigures()],
                       ),
                     ),
@@ -504,6 +561,7 @@ class TimerCenter extends StatelessWidget {
                 if (isRunning || suduckTimer.elapsedTime > 0)
                   GestureDetector(
                     onTap: () {
+                      SelectionHaptic.vibrate();
                       Navigator.pop(context);
                       suduckTimerNotifier.saveTimer();
                     },
@@ -531,17 +589,19 @@ class TimerCenter extends StatelessWidget {
             ),
           ),
         ),
-        Expanded(
-          flex: 2,
-          child: Row(
-            children: [
-              Expanded(
-                child: AdMobWidget.showBannerAd(60),
-              ),
-            ],
-          ),
-        ),
       ],
     );
+  }
+
+  Color _getReadableTextColor(Color backgroundColor) {
+    HSLColor hsl = HSLColor.fromColor(backgroundColor);
+
+    if (hsl.lightness > 0.7) {
+      return hsl.withLightness(0.2).toColor();
+    } else if (hsl.lightness < 0.3) {
+      return hsl.withLightness(0.9).toColor();
+    } else {
+      return hsl.withLightness(hsl.lightness < 0.5 ? 0.9 : 0.1).toColor();
+    }
   }
 }

--- a/lib/src/views/home/suduck_timer_focus_mode_screen.dart
+++ b/lib/src/views/home/suduck_timer_focus_mode_screen.dart
@@ -46,12 +46,12 @@ class _SuduckTimerFocusModeWidgetState
 
   // 추가할 변수들
   bool _isInitialized = false;
-  final _initializationDelay = const Duration(seconds: 180); //감지 초기화 지연시간
+  final _initializationDelay = const Duration(seconds: 60); //감지 초기화 지연시간
 
   @override
   void initState() {
     super.initState();
-    WakelockPlus.enable();
+    _initWakelock();
 
     // 지연후 센서 시작
     Future.delayed(_initializationDelay, () {
@@ -116,10 +116,6 @@ class _SuduckTimerFocusModeWidgetState
     _isInitialized = false;
     _stopAccelerometer();
     _alertTimer?.cancel();
-
-    if (mounted) {
-      WakelockPlus.disable();
-    }
 
     if (_colorController.isAnimating) {
       _colorController.stop();
@@ -203,16 +199,18 @@ class _SuduckTimerFocusModeWidgetState
 
         return AlertDialog(
           title: Center(child: Text("Dialog.Focus!").tr()),
-          content: Column(
-            children: [
-              Text("Dialog.YouarestudyingPutyourphonedownandfocus").tr(),
-              Gap(20),
-              SizedBox(
-                width: 150.w, // 원하는 너비
-                height: 250.h, // 원하는 높이
-                child: AdMobWidget.showExpandedBannerAd(), // 배너 광고의 높이와 일치
-              ),
-            ],
+          content: Container(
+            width: 280.w,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text("Dialog.YouarestudyingPutyourphonedownandfocus").tr(),
+                Gap(20),
+              ],
+            ),
+          ),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
           ),
         );
       },
@@ -306,6 +304,14 @@ class _SuduckTimerFocusModeWidgetState
       ),
     );
   }
+
+  Future<void> _initWakelock() async {
+    try {
+      await WakelockPlus.enable();
+    } catch (e) {
+      debugPrint('Wakelock enable error: $e');
+    }
+  }
 }
 
 class TimerCenter extends StatelessWidget {
@@ -360,7 +366,7 @@ class TimerCenter extends StatelessWidget {
               child: Text(
                 getFormatTime(suduckTimer.elapsedTime),
                 style: TextStyle(
-                  fontSize: 32.sp,
+                  fontSize: 46.sp,
                   fontWeight: FontWeight.w600,
                   color: Colors.white,
                   fontFeatures: [FontFeature.tabularFigures()],
@@ -472,7 +478,16 @@ class TimerCenter extends StatelessWidget {
             ),
           ),
         ),
-        Expanded(flex: 2, child: AdMobWidget.showExpandedBannerAd()),
+        Expanded(
+          flex: 2,
+          child: Row(
+            children: [
+              Expanded(
+                child: AdMobWidget.showBannerAd(60),
+              ),
+            ],
+          ),
+        ),
       ],
     );
   }

--- a/lib/src/views/home/widgets/breathing_exercise_widget.dart
+++ b/lib/src/views/home/widgets/breathing_exercise_widget.dart
@@ -36,10 +36,9 @@ class _BreathingExerciseWidgetState extends State<BreathingExerciseWidget> {
     }, // 입을 약간 벌리고 8초 동안 천천히 완전히 숨을 내쉬면서 "쉬-" 하는 소리를 냅니다.
   ];
 
-  final int _totalRepetitions = 4;
-  final Duration _introDuration =
-      const Duration(seconds: 3); // Increased intro duration slightly
-  final Duration _instructionPreviewDuration = const Duration(seconds: 2);
+  final int _totalRepetitions = 3;
+  final Duration _introDuration = const Duration(seconds: 2);
+  final Duration _instructionPreviewDuration = const Duration(seconds: 0);
 
   @override
   void initState() {

--- a/lib/src/views/home/widgets/timer/suduck_timer_widget.dart
+++ b/lib/src/views/home/widgets/timer/suduck_timer_widget.dart
@@ -6,10 +6,12 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../../core/enum/mxnRate.dart';
 import '../../../../../core/utils/get_formatted_time.dart';
+import '../../../../../core/widgets/admob_widget.dart';
 import '../../../../../core/widgets/mxnContainer.dart';
 import '../../../../providers/suduck_timer/suduck_timer_provider_2_0.dart';
 import '../../../../viewmodels/app_setting/app_setting_view_model.dart';
 import '../../../../viewmodels/timer/timer_bg_color_provider.dart';
+import '../breathing_exercise_widget.dart';
 
 class SuDuckTimerWidget extends ConsumerStatefulWidget {
   const SuDuckTimerWidget({super.key});
@@ -154,6 +156,9 @@ class _SuDuckTimerWidgetState extends ConsumerState<SuDuckTimerWidget>
                               } else {
                                 suduckTimerNotifier.stopTimer();
                               }
+                              if (!isRunning && suduckTimer.elapsedTime == 0) {
+                                _showBottomSheet();
+                              }
                             },
                             child: Container(
                               width: 120.w,
@@ -224,5 +229,52 @@ class _SuDuckTimerWidgetState extends ConsumerState<SuDuckTimerWidget>
   void dispose() {
     _colorController.dispose();
     super.dispose();
+  }
+
+  void _showBottomSheet() {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled:
+          true, // Keep true if content might exceed screen height initially
+      builder: (BuildContext context) {
+        // Give the container a fixed height to prevent resizing
+        return Container(
+          height: 380.h, // Set a fixed height
+          width: double.infinity,
+          // color: Colors.transparent, // Color is often set by theme, can remove if default is fine
+          padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 16.h),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              // Replace the Text widget with the BreathingExerciseWidget
+              SizedBox(
+                  height: 160.h, // Add some space above the exercise
+                  child: const BreathingExerciseWidget()),
+
+              SizedBox(height: 16.h),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                    onPressed: () {
+                      Navigator.pop(context);
+                    },
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.blue,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      padding: EdgeInsets.symmetric(vertical: 12.h),
+                    ),
+                    child: Text(tr("Common.Close"),
+                        style:
+                            TextStyle(fontSize: 16.sp, color: Colors.white))),
+              ),
+              SizedBox(height: 14.h),
+              AdMobWidget.showBannerAd(80.h), // 실제 광고 위젯
+            ],
+          ),
+        );
+      },
+    );
   }
 }


### PR DESCRIPTION
# 경고 메시지 햅틱 피드백 기능 추가

## 변경 사항
- 긴급 변경 - 집중모드에서 광고를 넣어 메모리와 CPU 사용량 증가로 앱 다운현상 발생으로 인해 광고삭제
- 집중모드에서 다이얼로그를 제거하고 타이머 부분에 경고 메시지 표시후 3초후 타이머 표시하도록 수정
- 집중 호흡법 UX 변경 타이머를 스타트할때 호흡법을 할 수 있도록 개선
- 경고 메시지 표시 시 햅틱 피드백 기능 구현
- 햅틱 피드백 관리를 위한 타이머 추가
- 햅틱 피드백 시작/중지 메서드 구현
- ver 1.1로 배포

## 상세 내용
### 햅틱 피드백 기능
- 경고 메시지가 표시되는 동안 500ms 간격으로 진동 피드백 제공
- _inactiveThreshold 시간(3초) 동안 지속되는 햅틱 피드백
- 앱 상태 변화에 따른 적절한 햅틱 피드백 관리

### 새로운 메서드
1. `_startHapticFeedback()`
   - 초기 햅틱 피드백 실행
   - 500ms 간격의 주기적 햅틱 피드백 시작
   - mounted 상태와 경고 메시지 표시 여부 확인

2. `_stopHapticFeedback()`
   - 햅틱 피드백 타이머 취소
   - 리소스 정리

### 기존 코드 수정
- `_resetAllStates()`: 햅틱 피드백 중지 로직 추가
- `dispose()`: 리소스 정리에 햅틱 피드백 중지 추가
- `_showConcentrationAlert()`: 햅틱 피드백 시작/중지 로직 통합

## 테스트 항목
- [ ] 경고 메시지 표시 시 햅틱 피드백 작동 확인
- [ ] _inactiveThreshold 시간 후 햅틱 피드백 자동 중지 확인
- [ ] 앱 종료 시 햅틱 피드백 정상 종료 확인
- [ ] 오류 발생 시 햅틱 피드백 정상 종료 확인

## 영향도
- 사용자 경험 개선: 시각적 경고에 촉각적 피드백 추가
- 배터리 사용량: 미미한 증가 예상 (진동 모터 사용)
- 성능: 영향 없음 (경량 타이머 사용)