### PR TITLE
튜토리얼 MBTI 검사 결과 저장 오류 수정

### DIFF
--- a/lib/src/viewmodels/user_setting/user_setting_view_model.dart
+++ b/lib/src/viewmodels/user_setting/user_setting_view_model.dart
@@ -71,9 +71,7 @@ class UserSettingViewModel extends _$UserSettingViewModel {
   Future<void> updateMbti(String mbtiType) async {
     state = const AsyncValue.loading();
     try {
-      final updatedSetting = state.value?.copyWith(mbti: mbtiType);
-      // Save to your data source here
-      state = AsyncValue.data(updatedSetting!);
+      await updateUserSetting(updatedMbti: mbtiType);
     } catch (e) {
       state = AsyncValue.error(e, StackTrace.current);
     }

--- a/lib/src/views/mbti/result_screen.dart
+++ b/lib/src/views/mbti/result_screen.dart
@@ -29,6 +29,15 @@ class _ResultScreenState extends State<ResultScreen> {
   final GlobalKey _printKey = GlobalKey();
   bool isLoading = false;
 
+  @override
+  void initState() {
+    super.initState();
+    // MBTI 결과를 부모 위젯에 전달
+    if (widget.onMbtiResult != null) {
+      widget.onMbtiResult!(widget.mbtiType);
+    }
+  }
+
   final Map<String, Map<String, String>> learningTips = {};
 
   Future<void> handleShare() async {
@@ -235,11 +244,6 @@ class _ResultScreenState extends State<ResultScreen> {
   }
 
   @override
-  void initState() {
-    super.initState();
-  }
-
-  @override
   Widget build(BuildContext context) {
     final tips = learningTips[widget.mbtiType] ?? {};
     return Scaffold(
@@ -298,9 +302,12 @@ class _ResultScreenState extends State<ResultScreen> {
     );
   }
 
-  void _MoveToThePageAfterTheMBTItest() {
+  void _MoveToThePageAfterTheMBTItest() async {
     print("MBTI 결과 화면에서 온 경우");
-    widget.onMbtiResult?.call(widget.mbtiType);
+    if (widget.onMbtiResult != null) {
+      await widget.onMbtiResult!(widget.mbtiType);
+    }
+    if (!mounted) return;
     int count = 0;
     Navigator.of(context).popUntil((route) {
       return count++ == 2;

--- a/lib/src/views/more/widgets/profile/profile_info_widget.dart
+++ b/lib/src/views/more/widgets/profile/profile_info_widget.dart
@@ -19,6 +19,7 @@ class ProfileInfoWidget extends ConsumerWidget {
     required this.selectDate,
     required this.validateNickName,
     required this.mbti,
+    this.onMbtiUpdate,
   });
 
   final TextEditingController nickNameController;
@@ -28,6 +29,7 @@ class ProfileInfoWidget extends ConsumerWidget {
   final FocusNode mbtiFocusNode;
   final void Function(DateTime selectedDate) selectDate;
   final void Function() validateNickName;
+  final void Function(String)? onMbtiUpdate;
   final String mbti;
 
   @override
@@ -119,6 +121,7 @@ class ProfileInfoWidget extends ConsumerWidget {
                                 .read(userSettingViewModelProvider.notifier)
                                 .updateMbti(mbtiType);
                             mbtiController.text = mbtiType;
+                            onMbtiUpdate?.call(mbtiType);
                             return mbtiType;
                           },
                         ),

--- a/lib/src/views/tutorial/widgets/profile/set_profile_widget.dart
+++ b/lib/src/views/tutorial/widgets/profile/set_profile_widget.dart
@@ -41,7 +41,7 @@ class _ProfileContainerWidgetState extends State<SetProfileWidget> {
 
     _nickNameController = TextEditingController(text: widget.nickName);
     _birthDateController = TextEditingController(text: widget.birthDate);
-    _mbtiController = TextEditingController(text: '');
+    _mbtiController = TextEditingController(text: widget.mbti ?? '');
 
     userSettingViewModel = widget.userSettingViewModel;
   }
@@ -82,6 +82,11 @@ class _ProfileContainerWidgetState extends State<SetProfileWidget> {
             mbtiFocusNode: _mbtiFocusNode,
             selectDate: selectDate,
             validateNickName: validateNickName,
+            onMbtiUpdate: (String newMbti) {
+              setState(() {
+                _mbtiController.text = newMbti;
+              });
+            },
           ),
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceAround,
@@ -107,6 +112,7 @@ class _ProfileContainerWidgetState extends State<SetProfileWidget> {
                   await userSettingViewModel.updateUserSetting(
                     updatedNickName: _nickNameController.text,
                     updatedAge: _birthDateController.text,
+                    updatedMbti: _mbtiController.text,
                   );
                   if (context.mounted) {
                     context.go('/tutorial/studySetting');


### PR DESCRIPTION
문제:
- 튜토리얼에서 MBTI 검사 후 결과가 Firebase에 저장되지 않는 문제
- 더보기 메뉴의 프로필에서 이전 MBTI 값이 계속 표시되는 문제

변경사항:
1. UserSettingViewModel의 updateMbti 메서드 수정
   - Firebase에 실제로 저장되도록 updateUserSetting 호출 추가

2. ResultScreen의 MBTI 결과 처리 로직 개선
   - 비동기 처리 추가
   - mounted 체크 추가
   - onMbtiResult 콜백 호출 방식 개선

3. ProfileInfoWidget에 MBTI 업데이트 콜백 추가
   - onMbtiUpdate 콜백 파라미터 추가
   - MBTI 결과 선택 시 부모 위젯에 알림 기능 추가

4. SetProfileWidget의 MBTI 컨트롤러 업데이트 로직 개선
   - onMbtiUpdate 콜백 구현
   - setState를 통한 UI 업데이트 보장

테스트 완료 사항:
- 튜토리얼에서 MBTI 검사 후 결과 저장 확인
- 더보기 메뉴의 프로필에서 업데이트된 MBTI 표시 확인
- MBTI 검사 결과가 Firebase에 정상적으로 저장되는지 확인